### PR TITLE
Do not try to modify workflow files

### DIFF
--- a/.github/.templatesyncignore
+++ b/.github/.templatesyncignore
@@ -1,0 +1,1 @@
+.github/workflows/

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -1,7 +1,5 @@
 name: template-sync
 
-permissions: write-all
-
 on:
   # manual trigger
   workflow_dispatch:
@@ -18,4 +16,3 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           source_repo_path: ProjectPythia/cookbook-template
-          pr_labels: <sync>  # optional, no default


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
It turns out that workflows cannot create PRs to modify workflow files without special PATs, e.g.: https://github.com/orgs/community/discussions/26711

Following [this advice](https://github.com/AndreasAugustin/actions-template-sync#troubleshooting) we will just ignore the workflows directory. This means no syncing of workflow changes from the template, but that's a restriction we might just have to live with.